### PR TITLE
Fix org autoloads

### DIFF
--- a/org-location-google-maps.el
+++ b/org-location-google-maps.el
@@ -128,8 +128,8 @@ location."
   (define-key org-agenda-mode-map "\C-c\M-l" 'org-location-google-maps))
 
 ;;;###autoload
-(eval-after-load "org" '(org-google-maps-key-bindings))
+(eval-after-load 'org '(org-google-maps-key-bindings))
 ;;;###autoload
-(eval-after-load "org-agenda" '(org-agenda-google-maps-key-bindings))
+(eval-after-load 'org-agenda '(org-agenda-google-maps-key-bindings))
 
 (provide 'org-location-google-maps)

--- a/org-location-google-maps.el
+++ b/org-location-google-maps.el
@@ -127,9 +127,9 @@ location."
   (define-key org-agenda-mode-map "\C-c\M-A" 'org-address-google-geocode-set)
   (define-key org-agenda-mode-map "\C-c\M-l" 'org-location-google-maps))
 
-;;;###autoload(eval-after-load "org" '(org-google-maps-key-bindings))
+;;;###autoload
 (eval-after-load "org" '(org-google-maps-key-bindings))
-;;;###autoload(eval-after-load "org-agenda" '(org-agenda-google-maps-key-bindings))
+;;;###autoload
 (eval-after-load "org-agenda" '(org-agenda-google-maps-key-bindings))
 
 (provide 'org-location-google-maps)


### PR DESCRIPTION
Without this, any file named `org.el` being loaded triggers the eval-after-load.

This unnecessary loads the whole org files in my configuration, adding 300ms of load time.