### PR TITLE
Drop GNU Emacs < 24.3 support

### DIFF
--- a/google-maps-base.el
+++ b/google-maps-base.el
@@ -25,8 +25,7 @@
 ;;
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl-lib)
 
 (defgroup google-maps nil
   "Google Maps."
@@ -50,10 +49,10 @@ FUNCTION.  SEQUENCE may be a list, a vector, a bool-vector, or a
 string."
   (mapconcat
    'identity
-   (remove-if predicate
-              (mapcar
-               function
-               sequence))
+   (cl-remove-if predicate
+                 (mapcar
+                  function
+                  sequence))
    separator))
 
 (defun google-maps-plist-delete (plist property)

--- a/google-maps-base.el
+++ b/google-maps-base.el
@@ -21,8 +21,9 @@
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; Functions and data used by Google Maps sub modules.
-;;
+
+;; Functions and data used by Google Maps submodules.
+
 ;;; Code:
 
 (require 'cl-lib)
@@ -145,3 +146,5 @@ PROPERTIES should have form '((property-name . format))."
      separator)))
 
 (provide 'google-maps-base)
+
+;;; google-maps-base.el ends here

--- a/google-maps-geocode.el
+++ b/google-maps-geocode.el
@@ -21,7 +21,9 @@
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; None
+
+;; Communicate with the Google Maps Geocoding API.
+
 ;;; Code:
 
 (require 'cl-lib)
@@ -139,3 +141,5 @@ If there is several results, the user is asked to pick one via
     (insert location)))
 
 (provide 'google-maps-geocode)
+
+;;; google-maps-geocode.el ends here

--- a/google-maps-geocode.el
+++ b/google-maps-geocode.el
@@ -121,13 +121,13 @@ If there is several results, the user is asked to pick one via
 (defun google-maps-geocode-location->coordinates (location)
   "Return a list containing latitude and longitude."
   (let ((geocode-location (google-maps-geocode-location location))
-	latitude longitude)
+        latitude longitude)
     (if (null (assoc 'geometry geocode-location))
-	(error (format "No geometry information for location: %s" location)))
+        (error (format "No geometry information for location: %s" location)))
     (setq latitude (cdr (assoc 'lat (assoc 'location (assoc 'geometry geocode-location)))))
     (setq longitude (cdr (assoc 'lng (assoc 'location (assoc 'geometry geocode-location)))))
     (if (or (null latitude) (null longitude))
-	(error (format "Null location coordinates: %s,%s" latitude longitude)))
+        (error (format "Null location coordinates: %s,%s" latitude longitude)))
     (list latitude longitude)))
 
 ;;;###autoload

--- a/google-maps-geocode.el
+++ b/google-maps-geocode.el
@@ -23,9 +23,8 @@
 ;;; Commentary:
 ;; None
 ;;; Code:
-(eval-when-compile
-  (require 'cl))
 
+(require 'cl-lib)
 (require 'json)
 (require 'google-maps-base)
 
@@ -94,7 +93,7 @@ Valid params are:
            results)
           nil t)))
     ;; Find entry with that location
-    (find-if
+    (cl-find-if
      `(lambda (entry)
         (string= (cdr (assoc 'formatted_address entry))
                  ,location))
@@ -104,10 +103,10 @@ Valid params are:
   "Converts geocoding results list to one result only.
 If there is several results, the user is asked to pick one via
 `google-maps-geocode-results->one-result-picked-by-user'."
-  (case (length results)
+  (pcase (length results)
     (0 nil)
     (1 (elt results 0))
-    (t (google-maps-geocode-results->one-result-picked-by-user results))))
+    (_ (google-maps-geocode-results->one-result-picked-by-user results))))
 
 (defun google-maps-geocode-location (location)
   (let* ((req (google-maps-geocode-request :address location))

--- a/google-maps-static.el
+++ b/google-maps-static.el
@@ -185,23 +185,23 @@ PATHS should have the form
   "Build a property list based on PLIST."
   ;; Make all markers upper case
   (let ((markers (plist-get plist :markers))
-	(set-size (if (or (not (plist-get plist :width)) (not (plist-get plist :height)))
-		      'google-maps-static-set-size
-		    'identity)))
+        (set-size (if (or (not (plist-get plist :width)) (not (plist-get plist :height)))
+                      'google-maps-static-set-size
+                    'identity)))
     (funcall set-size
-	     (google-maps-build-plist
-	      (if markers
-		  (plist-put plist :markers
-			     (mapcar
-			      (lambda (marker)
-				(let ((props (cdr marker)))
-				  (when props
-				    (let ((label (plist-get props :label)))
-				      (when label
-					(plist-put props :label (upcase label))))))
-				marker)
-			      markers))
-		plist)))))
+             (google-maps-build-plist
+              (if markers
+                  (plist-put plist :markers
+                             (mapcar
+                              (lambda (marker)
+                                (let ((props (cdr marker)))
+                                  (when props
+                                    (let ((label (plist-get props :label)))
+                                      (when label
+                                        (plist-put props :label (upcase label))))))
+                                marker)
+                              markers))
+                plist)))))
 
 (defun google-maps-static-build-url (plist)
   "Build a URL to request a static Google Map."

--- a/google-maps-static.el
+++ b/google-maps-static.el
@@ -21,6 +21,7 @@
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
 ;; All arguments are optional. Here is a full call example:
 ;;
 ;; (google-maps-static-show
@@ -28,19 +29,22 @@
 ;;  :maptype 'hybrid
 ;;  ;; :zoom 5
 ;;  :markers '((("Place Saint-Michel, Paris") . (:label ?M :color "blue"))
-;;             (("Jardin du Luxembourg, Paris" "Parc Montsouris, Paris") . (:label ?P :color "green")))
+;;             (("Jardin du Luxembourg, Paris" "Parc Montsouris, Paris")
+;;              . (:label ?P :color "green")))
 ;;  :visible '("44 rue de l'Ouest, Paris" "Montrouge")
 ;;  :paths '((("Tour Eiffel, Paris" "Arc de triomphe, Paris" "Panthéon, Paris")
 ;;            . (:weight 3 :color "black" :fillcolor "yellow"))))
 ;;
-;; All address can be specified as string, or with a format like this:
+;; All addresses can be specified as a string or in the following format:
 ;;
 ;; (LOCATION_NAME ((lat . LATITUDE) (lng. LONGITUDE)))
 ;;
+
 ;;; TODO:
+
 ;; - Resize map if frame is resized
 ;; - Add interactive code to build path
-;;
+
 ;;; Code:
 
 (require 'cl-lib)
@@ -649,3 +653,5 @@ string, it will remove centering."
 (google-maps-static-defun-move "east" 'lng +)
 
 (provide 'google-maps-static)
+
+;;; google-maps-static.el ends here

--- a/google-maps-static.el
+++ b/google-maps-static.el
@@ -42,9 +42,8 @@
 ;; - Add interactive code to build path
 ;;
 ;;; Code:
-(eval-when-compile
-  (require 'cl))
 
+(require 'cl-lib)
 (require 'google-maps-geocode)
 (require 'url-util)
 
@@ -496,7 +495,7 @@ If location is already a list, it's geocode. Otherwise, geocode the string and r
          (visible (plist-get plist :visible)))
     (apply 'google-maps-static-show
            (plist-put plist :visible
-                      (remove-if `(lambda (l) (string= l ,location)) visible)))))
+                      (cl-remove-if `(lambda (l) (string= l ,location)) visible)))))
 
 (defun google-maps-static-manage-visible (remove)
   "Add or remove a visible location. If REMOVE is set, remove it."
@@ -527,7 +526,7 @@ specify SIZE and COLOR of the LABEL."
   (let ((plist google-maps-static-params)
         (label (upcase label)))
     (apply 'google-maps-static-show (plist-put plist :markers
-                                               (remove-if
+                                               (cl-remove-if
                                                 (lambda (marker)
                                                   (eq (plist-get (cdr marker) :label) label))
                                                 (plist-get plist :markers))))))
@@ -625,7 +624,7 @@ string, it will remove centering."
          (error
           (substitute-command-keys
            "The map has no zoom level. Press \\[google-maps-static-zoom] to set a zoom level.")))
-       (let* ((coordinates (copy-list (cadr center)))
+       (let* ((coordinates (cl-copy-list (cadr center)))
               (value (assoc ,lat-or-lng coordinates))
               (coordinates (delq value coordinates)))
          ;; Zoom ratio seems to be 2, so `2^zoom * value' move the map quite

--- a/google-maps.el
+++ b/google-maps.el
@@ -23,8 +23,6 @@
 ;;; Commentary:
 ;; None
 ;;; Code:
-(eval-when-compile
-  (require 'cl))
 
 (require 'google-maps-geocode)
 (require 'google-maps-static)

--- a/google-maps.el
+++ b/google-maps.el
@@ -44,7 +44,7 @@ and do not ask the user for a more precise location."
   (interactive
    (list
     (if (and transient-mark-mode mark-active)
-	(buffer-substring-no-properties
+        (buffer-substring-no-properties
          (region-beginning) (region-end))
       (read-string "Location: " nil 'google-maps-history))))
   (let ((location (if no-geocoding

--- a/google-maps.el
+++ b/google-maps.el
@@ -2,8 +2,12 @@
 
 ;; Copyright (C) 2010 Julien Danjou
 
+;; Package-Requires: ((emacs "24.3"))
 ;; Author: Julien Danjou <julien@danjou.info>
 ;; Keywords: comm
+;; Homepage: https://julien.danjou.info/projects/emacs-packages#google-maps
+
+;; Google Maps requires at least GNU Emacs 24.3.
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -21,7 +25,9 @@
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; None
+
+;; Display Google Maps directly inside Emacs.
+
 ;;; Code:
 
 (require 'google-maps-geocode)
@@ -54,3 +60,5 @@ and do not ask the user for a more precise location."
                              :center location)))
 
 (provide 'google-maps)
+
+;;; google-maps.el ends here

--- a/org-location-google-maps.el
+++ b/org-location-google-maps.el
@@ -21,11 +21,12 @@
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
 ;; Integrate google-maps into org-mode.
 ;;
 ;; This allows you to press C-c M-l on an Org entry to get the Google Map of
 ;; your appointment.
-;;
+
 ;;; Code:
 
 (require 'google-maps)
@@ -133,3 +134,5 @@ location."
 (eval-after-load 'org-agenda '(org-agenda-google-maps-key-bindings))
 
 (provide 'org-location-google-maps)
+
+;;; org-location-google-maps.el ends here

--- a/org-location-google-maps.el
+++ b/org-location-google-maps.el
@@ -34,13 +34,14 @@
 (require 'org)
 (require 'org-agenda)
 
-(defcustom org-google-maps-location-properties '((if (boundp 'org-contacts-coordinates-property)
-						     org-contacts-coordinates-property
-						   "COORDINATES")
-						 "LOCATION"
-						 (if (boundp 'org-contacts-address-property)
-						     org-contacts-address-property
-						   "ADDRESS"))
+(defcustom org-google-maps-location-properties
+  '((if (boundp 'org-contacts-coordinates-property)
+        org-contacts-coordinates-property
+      "COORDINATES")
+    "LOCATION"
+    (if (boundp 'org-contacts-address-property)
+        org-contacts-address-property
+      "ADDRESS"))
   "Evaluated list of ORG properties storing location informations.
 'COORDINATES' or 'org-contacts-coordinates-property' store GPS coordinates.
 'LOCATION' store GPS coordinates, for backward compatibility.
@@ -54,7 +55,7 @@ Each element of the list is evaluated at run time by
 The first defined property of
 'org-google-maps-location-properties' is used."
   (let ((properties org-google-maps-location-properties)
-	location)
+        location)
     (while (and properties (null location))
       (setq location (org-entry-get nil (eval (car properties)) t))
       (setq properties (cdr properties)))
@@ -96,10 +97,10 @@ location."
   (interactive
    (list (read-string "Location: ")))
   (org-set-property (if (boundp 'org-contacts-address-property)
-			org-contacts-address-property
-		      "ADDRESS")
-		    (cdr (assoc 'formatted_address
-				(google-maps-geocode-location location)))))
+                        org-contacts-address-property
+                      "ADDRESS")
+                    (cdr (assoc 'formatted_address
+                                (google-maps-geocode-location location)))))
 
 ;;;###autoload
 (defun org-coordinates-google-geocode-set (location)
@@ -107,10 +108,10 @@ location."
   (interactive
    (list (read-string "Location: ")))
   (org-set-property (if (boundp 'org-contacts-coordinates-property)
-			org-contacts-coordinates-property
-		      "COORDINATES")
-		    (mapconcat 'number-to-string
-			       (google-maps-geocode-location->coordinates location) ",")))
+                        org-contacts-coordinates-property
+                      "COORDINATES")
+                    (mapconcat 'number-to-string
+                               (google-maps-geocode-location->coordinates location) ",")))
 
 ;;;###autoload
 (defun org-google-maps-key-bindings ()


### PR DESCRIPTION
As was mentioned in #1, requiring `cl` only at compile-time and yet making use of run-time functions leads to errors.

One solution would be to unconditionally require `cl` at runtime, but seeing as E24 is the _de facto_ default current version, I suggest switching to `cl-lib` as an entry-point to Common Lisp extensions.

Another possible route is to introduce external dependencies for the desired CL functionality, e.g. `seq` or `dash`, though the former already requires E24 and the latter [might eventually drop E23 support](https://github.com/magnars/dash.el/issues/130#issuecomment-149806476) as well.

This PR also makes package comments and indentation a bit more consistent; see commit messages for details.